### PR TITLE
Fix error checking when opening i2c failed

### DIFF
--- a/badge_fe310/src/main.c
+++ b/badge_fe310/src/main.c
@@ -68,7 +68,7 @@ void main(void)
 	spi_conf.cs = NULL,
 
 	i2c_dev = device_get_binding(CONFIG_I2C_0_NAME);
-	if (!spi_dev) {
+	if (!i2c_dev) {
 		printk("Failed to bind I2C driver\n");
 	}
 


### PR DESCRIPTION
Nothing critical.
I just found the bug, probably typo, when I saw the code at the presentation at RISC-V Summit last week.
Happy to have fixed.
I am considering to make the badge myself with KiCad and contribute later.
